### PR TITLE
make body align center and fix font size in nav

### DIFF
--- a/themes/landscape/_config.yml
+++ b/themes/landscape/_config.yml
@@ -2,7 +2,7 @@
 menu:
   Home: /
   Archives: /archives
-  About: /about
+  About Us: /about
 rss: /atom.xml
 
 # Content

--- a/themes/landscape/source/css/style.styl
+++ b/themes/landscape/source/css/style.styl
@@ -33,7 +33,7 @@ body
 .outer
   clearfix()
   max-width: (column-width + gutter-width) * columns + gutter-width
-  margin-top: banner-height
+  margin: banner-height auto
   padding: 0 gutter-width
 
 .inner
@@ -79,7 +79,7 @@ body
 
 .nav-item a
   display: inline-block
-  font-size: 22px
+  font-size: 18px
   padding: 0px
   margin: 28px auto
   text-align: center


### PR DESCRIPTION
make body align center and make the navbar's font size the same as the openalto main page.
